### PR TITLE
fix:   Root cause: web3 v7 (7.14.1) changed how RPC errors are surfac…

### DIFF
--- a/price_feeder/tasks.py
+++ b/price_feeder/tasks.py
@@ -266,7 +266,7 @@ class PriceFeederTaskBase(PendingTransactionsTasksManager):
                 nonce=nonce,
                 simulate=simulate
             )
-        except ValueError as err:
+        except (ValueError, exceptions.Web3RPCError) as err:
             log.error("Task :: {0} :: Error sending post price transaction! \n {1}".format(task.task_name, err))
             return task_result, None
 


### PR DESCRIPTION
…ed. Errors like

  -32010 ("insufficient funds") are now raised as web3.exceptions.Web3RPCError
  instead of ValueError, so the existing except ValueError didn't catch it. The
  exception propagated to tasks_manager.py where it was swallowed silently
  (logged at INFO with a full traceback).